### PR TITLE
mm: swap: Actually set QUEUE_FLAG_FAST bit

### DIFF
--- a/drivers/block/zram/zram_drv.c
+++ b/drivers/block/zram/zram_drv.c
@@ -889,6 +889,7 @@ static int create_device(struct zram *zram, int device_id)
 	zram->disk->private_data = zram;
 	snprintf(zram->disk->disk_name, 16, "zram%d", device_id);
 
+	__set_bit(QUEUE_FLAG_FAST, &zram->disk->queue->queue_flags);
 	/* Actual capacity set using syfs (/sys/block/zram<id>/disksize */
 	set_capacity(zram->disk, 0);
 	/* zram devices sort of resembles non-rotational disks */

--- a/drivers/input/touchscreen/synaptics_s5000/synaptics_i2c_rmi.c
+++ b/drivers/input/touchscreen/synaptics_s5000/synaptics_i2c_rmi.c
@@ -31,6 +31,9 @@
 #include <linux/i2c/synaptics_rmi.h>
 #include <linux/of_gpio.h>
 #include <linux/regulator/consumer.h>
+#ifdef CONFIG_FB
+#include <linux/fb.h>
+#endif
 
 #define DRIVER_NAME "synaptics_rmi4_i2c"
 
@@ -3987,6 +3990,11 @@ static void alloc_tsp_reboot_mode(void)
 }
 #endif
 
+#ifdef CONFIG_FB
+static int fb_notifier_callback(struct notifier_block *self,
+	unsigned long event, void *data);
+#endif
+
  /**
  * synaptics_rmi4_probe()
  *
@@ -4261,6 +4269,13 @@ err_tsp_reboot:
 #ifdef TSP_TURNOFF_AFTER_PROBE
 	synaptics_rmi4_stop_device(rmi4_data);
 #endif
+
+#ifdef CONFIG_FB
+	rmi4_data->fb_notif.notifier_call = fb_notifier_callback;
+	if (fb_register_client(&rmi4_data->fb_notif))
+		pr_err("%s: could not create fb notifier\n", __func__);
+#endif
+
 	return retval;
 
 err_sysfs:
@@ -4327,6 +4342,10 @@ static int __devexit synaptics_rmi4_remove(struct i2c_client *client)
 	synaptics_rmi4_release_support_fn(rmi4_data);
 
 	input_free_device(rmi4_data->input_dev);
+
+#ifdef CONFIG_FB
+	fb_unregister_client(&rmi4_data->fb_notif);
+#endif
 
 	kfree(rmi4_data);
 
@@ -4695,6 +4714,36 @@ static int synaptics_rmi4_resume(struct device *dev)
 	}
 
 	mutex_unlock(&rmi4_data->input_dev->mutex);
+
+	return 0;
+}
+#endif
+
+#ifdef CONFIG_FB
+static int fb_notifier_callback(struct notifier_block *self,
+				unsigned long event, void *data)
+{
+	struct fb_event *evdata = data;
+	struct synaptics_rmi4_data *rmi4_data =
+			container_of(self, struct synaptics_rmi4_data, fb_notif);
+
+	if (evdata && evdata->data && event == FB_EVENT_BLANK) {
+		int *blank = evdata->data;
+		switch (*blank) {
+		case FB_BLANK_UNBLANK:
+		case FB_BLANK_NORMAL:
+		case FB_BLANK_VSYNC_SUSPEND:
+		case FB_BLANK_HSYNC_SUSPEND:
+			synaptics_rmi4_resume(&rmi4_data->i2c_client->dev);
+			break;
+		case FB_BLANK_POWERDOWN:
+			synaptics_rmi4_suspend(&rmi4_data->i2c_client->dev);
+			break;
+		default:
+			/* Don't handle what we don't understand */
+			break;
+		}
+	}
 
 	return 0;
 }

--- a/drivers/input/touchscreen/synaptics_s5000/synaptics_i2c_rmi.h
+++ b/drivers/input/touchscreen/synaptics_s5000/synaptics_i2c_rmi.h
@@ -22,6 +22,10 @@
 #include <linux/earlysuspend.h>
 #endif
 
+#ifdef CONFIG_FB
+#include <linux/notifier.h>
+#endif
+
 /*#define dev_dbg(dev, fmt, arg...) dev_info(dev, fmt, ##arg)*/
 
 #define SYNAPTICS_DEVICE_NAME	"GT-I95XX"
@@ -404,6 +408,11 @@ struct synaptics_rmi4_data {
 	void (*register_cb)(struct synaptics_rmi_callbacks *);
 	struct synaptics_rmi_callbacks callbacks;
 #endif
+
+#ifdef CONFIG_FB
+	struct notifier_block fb_notif;
+#endif
+
 	int (*i2c_read)(struct synaptics_rmi4_data *pdata, unsigned short addr,
 			unsigned char *data, unsigned short length);
 	int (*i2c_write)(struct synaptics_rmi4_data *pdata, unsigned short addr,


### PR DESCRIPTION
This got lost in commit 699e3e8a. Without this flag,
we're not setting SWP_FAST.

Change-Id: Ic2acd9250ab0c6ce93e5ce6f75b58435c47ad678
